### PR TITLE
Add Three.js demo, fix WASM PR issues, update planning API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ docker/
 
 
 build/
+build-wasm/
 .cache/
 compile_commands.json
 *.out.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,6 @@ if(VAMP_FORCE_COLORED_OUTPUT)
   endif()
 endif()
 
-add_definitions(-w)
-
 project(
     vamp
     VERSION 0.2
@@ -77,10 +75,9 @@ if(EMSCRIPTEN)
   target_link_libraries(vamp_wasm_smoke PRIVATE vamp_cpp)
   set_target_properties(vamp_wasm_smoke PROPERTIES OUTPUT_NAME vamp_smoke SUFFIX ".mjs")
   add_executable(vamp_wasm_planning src/impl/vamp/bindings/wasm_planning.cc)
-  # Emscripten flags: ES module, no filesystem, export smoke and cwrap for script
   target_link_options(vamp_wasm_planning PRIVATE
-    "SHELL:-s EXPORTED_FUNCTIONS=['_vamp_wasm_planning']"
-    "SHELL:-s EXPORTED_RUNTIME_METHODS=['cwrap']"
+    "SHELL:-s EXPORTED_FUNCTIONS=['_vamp_wasm_planning','_vamp_plan','_vamp_get_path_data','_vamp_get_path_dof','_vamp_compute_fk','_vamp_get_obstacles','_vamp_get_obstacle_count','_vamp_get_robot_sphere_count']"
+    "SHELL:-s EXPORTED_RUNTIME_METHODS=['cwrap','HEAPF32']"
     "SHELL:-s MODULARIZE=1"
     "SHELL:-s EXPORT_ES6=1"
     "SHELL:-s ENVIRONMENT=web,worker,node"

--- a/README.md
+++ b/README.md
@@ -167,31 +167,28 @@ Requirements:
 - Emscripten SDK installed and activated
 - Node.js for running the smoke test
 
-Build and run a minimal smoke test:
+Build and run:
 ```bash
 # Configure with Emscripten toolchain
 emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release -DVAMP_BUILD_PYTHON_BINDINGS=OFF
 
-# Build headers-only deps and generate compile_commands.json, etc.
+# Build all WASM targets (smoke test, planning, Three.js demo)
 cmake --build build-wasm -j
-
-# Link the Wasm smoke test (Node environment)
-em++ -O3 -msimd128 -mrelaxed-simd \
-  -s WASM=1 -s MODULARIZE=1 -s ENVIRONMENT=node \
-  -s EXPORTED_FUNCTIONS='["_vamp_wasm_smoke"]' \
-  -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap"]' \
-  -I src/impl \
-  -o build-wasm/vamp_smoke.mjs \
-  src/impl/vamp/bindings/wasm_smoke.cc
 
 # Run the Node smoke test
 node scripts/wasm_smoke.js
-# Expected output: OK 17.000000
+# Expected output: OK 16.000000
+
+# Run the planning test
+node scripts/wasm_planning.js
+
+# Open the Three.js demo (serve from repo root)
+# npx serve . and open demo/threejs/index.html
 ```
 
 Notes:
-- Wasm SIMD is required (`-msimd128 -mrelaxed-simd`).
-- The Wasm build uses the native `<wasm_simd128.h>` backend and selects it automatically under Emscripten.
+- Wasm SIMD is required; the build automatically enables `-msimd128 -mrelaxed-simd`.
+- The Wasm build uses the native `<wasm_simd128.h>` backend, selected automatically under Emscripten.
 
 ### Using Clang instead of GCC
 You can force the use of Clang instead of GCC for compiling VAMP by uncommenting the line at the bottom of the `pyproject.toml` (or setting the corresponding CMake variable for C++ builds):

--- a/demo/threejs/index.html
+++ b/demo/threejs/index.html
@@ -188,7 +188,7 @@ function setStatus(msg) { statusEl.textContent = msg; }
 async function loadWasm() {
   try {
     setStatus('Loading WASM module...');
-    const mod = await import('../../build-wasm/vamp_planning.mjs');
+    const mod = await import('/build-wasm/vamp_planning.mjs');
     wasmModule = await mod.default();
 
     wasmFns.plan = wasmModule.cwrap('vamp_plan', 'number', []);
@@ -208,7 +208,7 @@ async function loadWasm() {
     btnReset.disabled = false;
     setStatus('Ready. Click "Plan Path" to run RRTC planning.');
   } catch (e) {
-    setStatus('Failed to load WASM: ' + e.message + '. Build with: emcmake cmake -S . -B build-wasm && cmake --build build-wasm -j');
+    setStatus('Failed to load WASM: ' + e.message + '. Copy artifacts from Docker: docker cp vamp-wasm-tmp:/vamp/build-wasm ./build-wasm, then serve from repo root: npx serve .');
     console.error(e);
   }
 }

--- a/demo/threejs/index.html
+++ b/demo/threejs/index.html
@@ -1,0 +1,405 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VAMP - WebAssembly Motion Planning Demo</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #1a1a2e; color: #e0e0e0; font-family: system-ui, sans-serif; overflow: hidden; }
+  #info {
+    position: absolute; top: 16px; left: 16px; z-index: 10;
+    background: rgba(0,0,0,0.7); padding: 16px 20px; border-radius: 8px;
+    max-width: 340px; font-size: 14px; line-height: 1.5;
+  }
+  #info h1 { font-size: 18px; margin-bottom: 8px; color: #60a5fa; }
+  #info p { margin-bottom: 6px; }
+  #status {
+    position: absolute; bottom: 16px; left: 50%; transform: translateX(-50%);
+    z-index: 10; background: rgba(0,0,0,0.7); padding: 10px 24px;
+    border-radius: 8px; font-size: 14px; text-align: center;
+  }
+  #controls {
+    position: absolute; top: 16px; right: 16px; z-index: 10;
+    background: rgba(0,0,0,0.7); padding: 16px 20px; border-radius: 8px;
+    font-size: 14px;
+  }
+  #controls button {
+    display: block; width: 100%; padding: 8px 16px; margin: 4px 0;
+    background: #2563eb; color: white; border: none; border-radius: 4px;
+    cursor: pointer; font-size: 14px;
+  }
+  #controls button:hover { background: #3b82f6; }
+  #controls button:disabled { background: #555; cursor: not-allowed; }
+  #controls label { display: block; margin-top: 8px; }
+  #controls input[type=range] { width: 100%; margin-top: 4px; }
+  canvas { display: block; }
+</style>
+</head>
+<body>
+
+<div id="info">
+  <h1>VAMP WebAssembly Demo</h1>
+  <p>Panda 7-DOF robot arm motion planning using SIMD-accelerated RRTC in WebAssembly.</p>
+  <p>Obstacles shown as red spheres. Robot collision model shown as blue/green spheres.</p>
+</div>
+
+<div id="controls">
+  <button id="btn-plan" disabled>Plan Path</button>
+  <button id="btn-play" disabled>Play Animation</button>
+  <button id="btn-reset" disabled>Reset</button>
+  <label>Speed
+    <input id="speed" type="range" min="0.1" max="5" step="0.1" value="1" />
+  </label>
+</div>
+
+<div id="status">Loading WASM module...</div>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+  }
+}
+</script>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+// ---- Three.js scene setup ----
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x1a1a2e);
+scene.fog = new THREE.Fog(0x1a1a2e, 8, 20);
+
+const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.01, 100);
+camera.position.set(1.5, 1.5, 2.0);
+camera.lookAt(0, 0.4, 0);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+document.body.appendChild(renderer.domElement);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 0.4, 0);
+controls.enableDamping = true;
+controls.dampingFactor = 0.1;
+
+// Lights
+const ambientLight = new THREE.AmbientLight(0x404060, 1.5);
+scene.add(ambientLight);
+
+const dirLight = new THREE.DirectionalLight(0xffffff, 2.0);
+dirLight.position.set(3, 5, 3);
+dirLight.castShadow = true;
+dirLight.shadow.mapSize.set(1024, 1024);
+scene.add(dirLight);
+
+const fillLight = new THREE.DirectionalLight(0x8888ff, 0.5);
+fillLight.position.set(-2, 2, -1);
+scene.add(fillLight);
+
+// Ground plane
+const groundGeo = new THREE.PlaneGeometry(6, 6);
+const groundMat = new THREE.MeshStandardMaterial({ color: 0x222244, roughness: 0.9 });
+const ground = new THREE.Mesh(groundGeo, groundMat);
+ground.rotation.x = -Math.PI / 2;
+ground.receiveShadow = true;
+scene.add(ground);
+
+// Grid helper
+const grid = new THREE.GridHelper(4, 20, 0x333366, 0x333366);
+grid.position.y = 0.001;
+scene.add(grid);
+
+// Axis helper
+const axes = new THREE.AxesHelper(0.3);
+scene.add(axes);
+
+// ---- Materials ----
+const robotMat = new THREE.MeshStandardMaterial({
+  color: 0x4488ff, roughness: 0.3, metalness: 0.6, transparent: true, opacity: 0.85
+});
+const robotGhostMat = new THREE.MeshStandardMaterial({
+  color: 0x44ff88, roughness: 0.4, metalness: 0.3, transparent: true, opacity: 0.15
+});
+const obstacleMat = new THREE.MeshStandardMaterial({
+  color: 0xff4444, roughness: 0.4, metalness: 0.2, transparent: true, opacity: 0.5
+});
+const pathMat = new THREE.LineBasicMaterial({ color: 0xffff44, linewidth: 2 });
+
+// ---- Robot sphere meshes ----
+const ROBOT_SPHERES = 59;
+const sphereGeo = new THREE.SphereGeometry(1, 12, 8);
+const robotMeshes = [];
+for (let i = 0; i < ROBOT_SPHERES; i++) {
+  const m = new THREE.Mesh(sphereGeo, robotMat);
+  m.castShadow = true;
+  scene.add(m);
+  robotMeshes.push(m);
+}
+
+// Ghost meshes for start/goal
+const startGhosts = [];
+const goalGhosts = [];
+for (let i = 0; i < ROBOT_SPHERES; i++) {
+  const sm = new THREE.Mesh(sphereGeo, robotGhostMat.clone());
+  sm.material.color.set(0x44ff88);
+  sm.material.opacity = 0.2;
+  scene.add(sm);
+  startGhosts.push(sm);
+
+  const gm = new THREE.Mesh(sphereGeo, robotGhostMat.clone());
+  gm.material.color.set(0xff8844);
+  gm.material.opacity = 0.2;
+  scene.add(gm);
+  goalGhosts.push(gm);
+}
+
+// Obstacle meshes (created after WASM loads)
+const obstacleMeshes = [];
+
+// Path line
+let pathLine = null;
+
+// ---- WASM module loading ----
+const statusEl = document.getElementById('status');
+const btnPlan = document.getElementById('btn-plan');
+const btnPlay = document.getElementById('btn-play');
+const btnReset = document.getElementById('btn-reset');
+const speedSlider = document.getElementById('speed');
+
+let wasmModule = null;
+let wasmFns = {};
+
+// Path data
+let pathConfigs = [];  // array of Float32Array(7)
+let pathLength = 0;
+let animFrame = 0;
+let animating = false;
+let animTime = 0;
+
+function setStatus(msg) { statusEl.textContent = msg; }
+
+async function loadWasm() {
+  try {
+    setStatus('Loading WASM module...');
+    const mod = await import('../../build-wasm/vamp_planning.mjs');
+    wasmModule = await mod.default();
+
+    wasmFns.plan = wasmModule.cwrap('vamp_plan', 'number', []);
+    wasmFns.getPathData = wasmModule.cwrap('vamp_get_path_data', 'number', []);
+    wasmFns.getPathDof = wasmModule.cwrap('vamp_get_path_dof', 'number', []);
+    wasmFns.computeFk = wasmModule.cwrap('vamp_compute_fk', 'number',
+      ['number', 'number', 'number', 'number', 'number', 'number', 'number']);
+    wasmFns.getObstacles = wasmModule.cwrap('vamp_get_obstacles', 'number', []);
+    wasmFns.getObstacleCount = wasmModule.cwrap('vamp_get_obstacle_count', 'number', []);
+    wasmFns.getRobotSphereCount = wasmModule.cwrap('vamp_get_robot_sphere_count', 'number', []);
+
+    setupObstacles();
+    showConfig([0, -0.785, 0, -2.356, 0, 1.571, 0.785]); // start config
+    showGhosts();
+
+    btnPlan.disabled = false;
+    btnReset.disabled = false;
+    setStatus('Ready. Click "Plan Path" to run RRTC planning.');
+  } catch (e) {
+    setStatus('Failed to load WASM: ' + e.message + '. Build with: emcmake cmake -S . -B build-wasm && cmake --build build-wasm -j');
+    console.error(e);
+  }
+}
+
+function setupObstacles() {
+  const count = wasmFns.getObstacleCount();
+  const ptr = wasmFns.getObstacles();
+  const data = new Float32Array(wasmModule.HEAPF32.buffer, ptr, count * 4);
+
+  for (let i = 0; i < count; i++) {
+    const x = data[i * 4 + 0];
+    const y = data[i * 4 + 1];
+    const z = data[i * 4 + 2];
+    const r = data[i * 4 + 3];
+    const mesh = new THREE.Mesh(sphereGeo, obstacleMat);
+    mesh.position.set(x, z, -y);  // VAMP uses Z-up, Three.js uses Y-up
+    mesh.scale.setScalar(r);
+    mesh.castShadow = true;
+    scene.add(mesh);
+    obstacleMeshes.push(mesh);
+  }
+}
+
+function readFkSpheres(config) {
+  const ptr = wasmFns.computeFk(config[0], config[1], config[2], config[3], config[4], config[5], config[6]);
+  const nSpheres = wasmFns.getRobotSphereCount();
+  return new Float32Array(wasmModule.HEAPF32.buffer, ptr, nSpheres * 4);
+}
+
+function showConfig(config) {
+  const data = readFkSpheres(config);
+  for (let i = 0; i < ROBOT_SPHERES; i++) {
+    const x = data[i * 4 + 0];
+    const y = data[i * 4 + 1];
+    const z = data[i * 4 + 2];
+    const r = data[i * 4 + 3];
+    robotMeshes[i].position.set(x, z, -y);
+    robotMeshes[i].scale.setScalar(r);
+  }
+}
+
+function showGhosts() {
+  // Start ghost
+  const startCfg = [0, -0.785, 0, -2.356, 0, 1.571, 0.785];
+  const startData = readFkSpheres(startCfg);
+  for (let i = 0; i < ROBOT_SPHERES; i++) {
+    startGhosts[i].position.set(startData[i*4], startData[i*4+2], -startData[i*4+1]);
+    startGhosts[i].scale.setScalar(startData[i*4+3]);
+  }
+
+  // Goal ghost
+  const goalCfg = [2.35, 1.0, 0, -0.8, 0, 2.5, 0.785];
+  const goalData = readFkSpheres(goalCfg);
+  for (let i = 0; i < ROBOT_SPHERES; i++) {
+    goalGhosts[i].position.set(goalData[i*4], goalData[i*4+2], -goalData[i*4+1]);
+    goalGhosts[i].scale.setScalar(goalData[i*4+3]);
+  }
+}
+
+function buildPathLine() {
+  if (pathLine) { scene.remove(pathLine); pathLine.geometry.dispose(); }
+  if (pathConfigs.length < 2) return;
+
+  // Use end-effector position (last few spheres) to trace path
+  const points = [];
+  for (const config of pathConfigs) {
+    const data = readFkSpheres(config);
+    // Use sphere 0 (base-ish) and last sphere for EE trace
+    const eeIdx = ROBOT_SPHERES - 1;
+    const x = data[eeIdx * 4 + 0];
+    const y = data[eeIdx * 4 + 1];
+    const z = data[eeIdx * 4 + 2];
+    points.push(new THREE.Vector3(x, z, -y));
+  }
+
+  const geo = new THREE.BufferGeometry().setFromPoints(points);
+  pathLine = new THREE.Line(geo, pathMat);
+  scene.add(pathLine);
+}
+
+// ---- Event handlers ----
+btnPlan.addEventListener('click', () => {
+  btnPlan.disabled = true;
+  btnPlay.disabled = true;
+  setStatus('Planning with RRTC...');
+
+  // Use setTimeout to let the UI update
+  setTimeout(() => {
+    try {
+      const t0 = performance.now();
+      pathLength = wasmFns.plan();
+      const elapsed = (performance.now() - t0).toFixed(1);
+
+      if (pathLength === 0) {
+        setStatus('Planning failed - no path found. Try again.');
+        btnPlan.disabled = false;
+        return;
+      }
+
+      const dof = wasmFns.getPathDof();
+      const ptr = wasmFns.getPathData();
+      const raw = new Float32Array(wasmModule.HEAPF32.buffer, ptr, pathLength * dof);
+
+      pathConfigs = [];
+      for (let i = 0; i < pathLength; i++) {
+        pathConfigs.push(Array.from(raw.slice(i * dof, (i + 1) * dof)));
+      }
+
+      buildPathLine();
+      showConfig(pathConfigs[0]);
+
+      setStatus(`Path found: ${pathLength} waypoints in ${elapsed}ms. Click "Play Animation".`);
+      btnPlan.disabled = false;
+      btnPlay.disabled = false;
+    } catch (e) {
+      setStatus('Planning error: ' + e.message);
+      btnPlan.disabled = false;
+      console.error(e);
+    }
+  }, 50);
+});
+
+btnPlay.addEventListener('click', () => {
+  if (pathConfigs.length === 0) return;
+  animating = !animating;
+  btnPlay.textContent = animating ? 'Pause' : 'Play Animation';
+  if (animating) {
+    animTime = 0;
+    setStatus('Animating path...');
+  }
+});
+
+btnReset.addEventListener('click', () => {
+  animating = false;
+  animTime = 0;
+  animFrame = 0;
+  btnPlay.textContent = 'Play Animation';
+  pathConfigs = [];
+  if (pathLine) { scene.remove(pathLine); pathLine.geometry.dispose(); pathLine = null; }
+  showConfig([0, -0.785, 0, -2.356, 0, 1.571, 0.785]);
+  setStatus('Reset. Click "Plan Path" to plan again.');
+});
+
+// ---- Animation loop ----
+const clock = new THREE.Clock();
+
+function animate() {
+  requestAnimationFrame(animate);
+  const dt = clock.getDelta();
+  controls.update();
+
+  if (animating && pathConfigs.length > 1) {
+    const speed = parseFloat(speedSlider.value);
+    animTime += dt * speed;
+
+    // Ping-pong: go forward then backward
+    const totalDuration = pathConfigs.length - 1;
+    const cycleTime = animTime % (totalDuration * 2);
+    let t;
+    if (cycleTime <= totalDuration) {
+      t = cycleTime;
+    } else {
+      t = totalDuration * 2 - cycleTime;
+    }
+
+    const idx = Math.min(Math.floor(t), pathConfigs.length - 2);
+    const frac = t - idx;
+
+    // Interpolate between two adjacent configs
+    const c0 = pathConfigs[idx];
+    const c1 = pathConfigs[idx + 1];
+    const config = c0.map((v, j) => v + frac * (c1[j] - v));
+
+    showConfig(config);
+    const progress = ((t / totalDuration) * 100).toFixed(0);
+    setStatus(`Animating: ${progress}%`);
+  }
+
+  renderer.render(scene, camera);
+}
+
+// Handle resize
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});
+
+// Start
+loadWasm();
+animate();
+</script>
+</body>
+</html>

--- a/docker/wasm.dockerfile
+++ b/docker/wasm.dockerfile
@@ -31,11 +31,12 @@ COPY . /vamp
 WORKDIR /vamp
 
 # Configure with Emscripten toolchain
-# Point Eigen3_DIR to the system-installed Eigen3 CMake config
+# CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH allows find_package to locate
+# host-installed Eigen3 despite Emscripten's sysroot-only default
 RUN emcmake cmake -S . -B build-wasm \
     -DCMAKE_BUILD_TYPE=Release \
     -DVAMP_BUILD_PYTHON_BINDINGS=OFF \
-    -DEigen3_DIR=/usr/lib/cmake/eigen3
+    -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
 
 # Build all WASM targets
 RUN cmake --build build-wasm -j$(nproc)

--- a/docker/wasm.dockerfile
+++ b/docker/wasm.dockerfile
@@ -3,15 +3,10 @@
 # Build:
 #   docker build -f docker/wasm.dockerfile -t vamp-wasm .
 #
-# Extract build artifacts:
-#   docker run --rm vamp-wasm cat /vamp/build-wasm/vamp_planning.mjs > build-wasm/vamp_planning.mjs
-#   docker run --rm vamp-wasm cat /vamp/build-wasm/vamp_planning.wasm > build-wasm/vamp_planning.wasm
-#   docker run --rm vamp-wasm cat /vamp/build-wasm/vamp_smoke.mjs > build-wasm/vamp_smoke.mjs
-#   docker run --rm vamp-wasm cat /vamp/build-wasm/vamp_smoke.wasm > build-wasm/vamp_smoke.wasm
-#
-# Or copy everything out:
+# Extract build artifacts (note: trailing /. copies contents, not the directory):
+#   mkdir -p build-wasm
 #   docker create --name vamp-wasm-tmp vamp-wasm
-#   docker cp vamp-wasm-tmp:/vamp/build-wasm ./build-wasm
+#   docker cp vamp-wasm-tmp:/vamp/build-wasm/. ./build-wasm
 #   docker rm vamp-wasm-tmp
 #
 # Run smoke test inside container:

--- a/docker/wasm.dockerfile
+++ b/docker/wasm.dockerfile
@@ -1,0 +1,50 @@
+# Dockerfile for building VAMP WebAssembly targets with Emscripten
+#
+# Build:
+#   docker build -f docker/wasm.dockerfile -t vamp-wasm .
+#
+# Extract build artifacts:
+#   docker run --rm vamp-wasm cat /vamp/build-wasm/vamp_planning.mjs > build-wasm/vamp_planning.mjs
+#   docker run --rm vamp-wasm cat /vamp/build-wasm/vamp_planning.wasm > build-wasm/vamp_planning.wasm
+#   docker run --rm vamp-wasm cat /vamp/build-wasm/vamp_smoke.mjs > build-wasm/vamp_smoke.mjs
+#   docker run --rm vamp-wasm cat /vamp/build-wasm/vamp_smoke.wasm > build-wasm/vamp_smoke.wasm
+#
+# Or copy everything out:
+#   docker create --name vamp-wasm-tmp vamp-wasm
+#   docker cp vamp-wasm-tmp:/vamp/build-wasm ./build-wasm
+#   docker rm vamp-wasm-tmp
+#
+# Run smoke test inside container:
+#   docker run --rm vamp-wasm node scripts/wasm_smoke.js
+#   docker run --rm vamp-wasm node scripts/wasm_planning.js
+
+FROM emscripten/emsdk:3.1.74
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Eigen3 headers (header-only, works for cross-compilation)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libeigen3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . /vamp
+WORKDIR /vamp
+
+# Configure with Emscripten toolchain
+# Point Eigen3_DIR to the system-installed Eigen3 CMake config
+RUN emcmake cmake -S . -B build-wasm \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DVAMP_BUILD_PYTHON_BINDINGS=OFF \
+    -DEigen3_DIR=/usr/lib/cmake/eigen3
+
+# Build all WASM targets
+RUN cmake --build build-wasm -j$(nproc)
+
+# Verify builds succeeded
+RUN ls -la build-wasm/vamp_smoke.mjs build-wasm/vamp_smoke.wasm \
+          build-wasm/vamp_planning.mjs build-wasm/vamp_planning.wasm
+
+# Run smoke test
+RUN node scripts/wasm_smoke.js
+
+CMD ["node", "scripts/wasm_planning.js"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,13 +86,17 @@ Visualization is enabled by `--visualize`, which shows the plan with the PyBulle
 # Other Scripts
 
 ## Wasm32 smoke test
-If you have [Emscripten](https://emscripten.org) installed and activated (emcc/em++ in PATH), you can build a minimal wasm32 SIMD smoke module and run a quick Node test:
+If you have [Emscripten](https://emscripten.org) installed and activated (emcc/em++ in PATH), you can build the wasm32 SIMD modules and run tests:
 
-1) Configure a separate build directory using Emscripten's toolchain (e.g., `emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release`).
-2) Build the `vamp_wasm_smoke` target: `cmake --build build-wasm -j`.
-3) Run the Node test: `node scripts/wasm_smoke.js`.
+1) Configure a separate build directory: `emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release`.
+2) Build all WASM targets: `cmake --build build-wasm -j`.
+3) Run the smoke test: `node scripts/wasm_smoke.js`.
+4) Run the planning test: `node scripts/wasm_planning.js`.
 
-This produces `build-wasm/vamp_smoke.mjs` and exercises the Wasm SIMD paths in the collision and vector code.
+## Three.js Demo
+A browser-based 3D visualization of Panda robot motion planning is available in `demo/threejs/index.html`.
+After building the WASM targets, serve the repo root with any HTTP server (e.g., `npx serve .`) and open
+`demo/threejs/index.html`. The demo runs RRTC planning in WebAssembly and animates the robot path using Three.js.
 
 ## `visualize_ompl.py`
 If you have the [OMPL](https://ompl.kavrakilab.org/) Python Bindings installed (we recommend using the [pre-built wheels](https://github.com/ompl/ompl/releases/tag/prerelease)) you can also test problems against OMPL using PyBullet's collision checking with this script.

--- a/scripts/wasm_planning.js
+++ b/scripts/wasm_planning.js
@@ -1,4 +1,4 @@
-// Minimal Node smoke test for the Wasm SIMD backend
+// Node smoke test for the Wasm SIMD planning backend
 // Usage after building the module (see README):
 //   node scripts/wasm_planning.js
 
@@ -6,12 +6,43 @@
   try {
     const mod = await import('../build-wasm/vamp_planning.mjs');
     const instance = await mod.default();
-    const smoke = instance.cwrap('vamp_wasm_planning', 'number', []);
-    const res = smoke();
-    console.log('OK', Number(res).toFixed(6));
+
+    // Test planning API
+    const plan = instance.cwrap('vamp_plan', 'number', []);
+    const getPathDof = instance.cwrap('vamp_get_path_dof', 'number', []);
+    const getPathData = instance.cwrap('vamp_get_path_data', 'number', []);
+    const getObstacleCount = instance.cwrap('vamp_get_obstacle_count', 'number', []);
+    const getRobotSphereCount = instance.cwrap('vamp_get_robot_sphere_count', 'number', []);
+    const computeFk = instance.cwrap('vamp_compute_fk', 'number',
+      ['number', 'number', 'number', 'number', 'number', 'number', 'number']);
+
+    console.log('Obstacles:', getObstacleCount());
+    console.log('Robot spheres:', getRobotSphereCount());
+    console.log('DOF:', getPathDof());
+
+    // Test FK
+    const fkPtr = computeFk(0, -0.785, 0, -2.356, 0, 1.571, 0.785);
+    const fkData = new Float32Array(instance.HEAPF32.buffer, fkPtr, getRobotSphereCount() * 4);
+    console.log('FK sphere 0: x=' + fkData[0].toFixed(3) + ' y=' + fkData[1].toFixed(3) + ' z=' + fkData[2].toFixed(3) + ' r=' + fkData[3].toFixed(3));
+
+    // Run planning
+    const t0 = performance.now();
+    const pathLen = plan();
+    const elapsed = (performance.now() - t0).toFixed(1);
+
+    if (pathLen > 0) {
+      const dof = getPathDof();
+      const ptr = getPathData();
+      const pathData = new Float32Array(instance.HEAPF32.buffer, ptr, pathLen * dof);
+      console.log('OK path_length=' + pathLen + ' time=' + elapsed + 'ms');
+      console.log('First config:', Array.from(pathData.slice(0, dof)).map(v => v.toFixed(3)).join(', '));
+      console.log('Last config:', Array.from(pathData.slice((pathLen - 1) * dof, pathLen * dof)).map(v => v.toFixed(3)).join(', '));
+    } else {
+      console.log('Planning failed - no path found');
+      process.exit(1);
+    }
   } catch (e) {
     console.error('Planning test failed:', e);
     process.exit(1);
   }
 })();
-

--- a/src/impl/vamp/bindings/wasm_planning.cc
+++ b/src/impl/vamp/bindings/wasm_planning.cc
@@ -1,13 +1,11 @@
 #include <cstdlib>
 #include <cstdint>
+#include <cstring>
 
 #include <emscripten/emscripten.h>
 
 #include <vector>
 #include <array>
-#include <utility>
-#include <iostream>
-#include <iomanip>
 
 #include <vamp/collision/factory.hh>
 #include <vamp/planning/validate.hh>
@@ -19,97 +17,151 @@
 extern "C" {
 
 using Robot = vamp::robots::Panda;
-static constexpr const std::size_t rake = vamp::FloatVectorWidth;
+static constexpr std::size_t rake = vamp::FloatVectorWidth;
 using EnvironmentInput = vamp::collision::Environment<float>;
 using EnvironmentVector = vamp::collision::Environment<vamp::FloatVector<rake>>;
 using RRTC = vamp::planning::RRTC<Robot, rake, Robot::resolution>;
 
-// Start and goal configurations
+// Start and goal configurations (Panda joint angles in radians)
 static constexpr Robot::ConfigurationArray start = {0., -0.785, 0., -2.356, 0., 1.571, 0.785};
 static constexpr Robot::ConfigurationArray goal = {2.35, 1., 0., -0.8, 0, 2.5, 0.785};
 
-// Spheres for the cage problem - (x, y, z) center coordinates with fixed, common radius defined below
-static const std::vector<std::array<float, 3>> problem = {
-    {0.55, 0, 0.25},
-    {0.35, 0.35, 0.25},
-    {0, 0.55, 0.25},
-    {-0.55, 0, 0.25},
-    {-0.35, -0.35, 0.25},
-    {0, -0.55, 0.25},
-    {0.35, -0.35, 0.25},
-    {0.35, 0.35, 0.8},
-    {0, 0.55, 0.8},
-    {-0.35, 0.35, 0.8},
-    {-0.55, 0, 0.8},
-    {-0.35, -0.35, 0.8},
-    {0, -0.55, 0.8},
-    {0.35, -0.35, 0.8},
+// Sphere cage obstacle positions (x, y, z)
+static const std::vector<std::array<float, 3>> obstacle_positions = {
+    {0.55, 0, 0.25},     {0.35, 0.35, 0.25},  {0, 0.55, 0.25},     {-0.55, 0, 0.25},
+    {-0.35, -0.35, 0.25},{0, -0.55, 0.25},     {0.35, -0.35, 0.25}, {0.35, 0.35, 0.8},
+    {0, 0.55, 0.8},      {-0.35, 0.35, 0.8},   {-0.55, 0, 0.8},     {-0.35, -0.35, 0.8},
+    {0, -0.55, 0.8},     {0.35, -0.35, 0.8},
 };
 
-// Radius for obstacle spheres
-static constexpr float radius = 0.2;
+static constexpr float obstacle_radius = 0.2;
+
+// Buffers for returning data to JavaScript
+static std::vector<float> path_buffer;
+static std::vector<float> sphere_buffer;
+static float obstacle_buffer[14 * 4]; // 14 obstacles * (x, y, z, r)
 
 EMSCRIPTEN_KEEPALIVE
-float vamp_wasm_planning()
+int vamp_get_obstacle_count()
 {
+    return static_cast<int>(obstacle_positions.size());
+}
 
-    std::cout << "Running WASM planning test" << std::endl;
-
-    // Build sphere cage environment
-    EnvironmentInput environment;
-    for (const auto &sphere : problem)
+EMSCRIPTEN_KEEPALIVE
+float *vamp_get_obstacles()
+{
+    for (std::size_t i = 0; i < obstacle_positions.size(); ++i)
     {
-        environment.spheres.emplace_back(vamp::collision::factory::sphere::array(sphere, radius));
+        obstacle_buffer[i * 4 + 0] = obstacle_positions[i][0];
+        obstacle_buffer[i * 4 + 1] = obstacle_positions[i][1];
+        obstacle_buffer[i * 4 + 2] = obstacle_positions[i][2];
+        obstacle_buffer[i * 4 + 3] = obstacle_radius;
+    }
+    return obstacle_buffer;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int vamp_get_robot_sphere_count()
+{
+    return static_cast<int>(Robot::n_spheres);
+}
+
+EMSCRIPTEN_KEEPALIVE
+float *vamp_compute_fk(float j0, float j1, float j2, float j3, float j4, float j5, float j6)
+{
+    sphere_buffer.resize(Robot::n_spheres * 4);
+
+    Robot::ConfigurationBlock<rake> q;
+    // Set the first lane of each joint dimension
+    q[0] = vamp::FloatVector<rake>(j0);
+    q[1] = vamp::FloatVector<rake>(j1);
+    q[2] = vamp::FloatVector<rake>(j2);
+    q[3] = vamp::FloatVector<rake>(j3);
+    q[4] = vamp::FloatVector<rake>(j4);
+    q[5] = vamp::FloatVector<rake>(j5);
+    q[6] = vamp::FloatVector<rake>(j6);
+
+    Robot::Spheres<rake> spheres;
+    Robot::sphere_fk(q, spheres);
+
+    for (std::size_t i = 0; i < Robot::n_spheres; ++i)
+    {
+        sphere_buffer[i * 4 + 0] = spheres.x[i].element(0);
+        sphere_buffer[i * 4 + 1] = spheres.y[i].element(0);
+        sphere_buffer[i * 4 + 2] = spheres.z[i].element(0);
+        sphere_buffer[i * 4 + 3] = spheres.r[i].element(0);
     }
 
-    std::cout << "Environment built" << std::endl;
+    return sphere_buffer.data();
+}
 
+EMSCRIPTEN_KEEPALIVE
+int vamp_plan()
+{
+    // Build sphere cage environment
+    EnvironmentInput environment;
+    for (const auto &sphere : obstacle_positions)
+    {
+        environment.spheres.emplace_back(vamp::collision::factory::sphere::array(sphere, obstacle_radius));
+    }
     environment.sort();
     auto env_v = EnvironmentVector(environment);
 
-    std::cout << "Environment vector built" << std::endl;
-
-    // Create RNG for planning
     auto rng = std::make_shared<vamp::rng::Halton<Robot>>();
 
-
-    std::cout << "RNG built" << std::endl;
-    // Setup RRTC and plan
     vamp::planning::RRTCSettings rrtc_settings;
     rrtc_settings.range = 1.0;
 
     auto result =
         RRTC::solve(Robot::Configuration(start), Robot::Configuration(goal), env_v, rrtc_settings, rng);
 
-    std::cout << "RRTC solved" << std::endl;
-    std::cout << "result.nanoseconds: " << result.nanoseconds << std::endl;
-    std::cout << "result.iterations: " << result.iterations << std::endl;
-    std::cout << "result.size: " << result.size[0] << ", " << result.size[1] << std::endl;
-    std::cout << "result.path.size: " << result.path.size() << std::endl;
-
-    // If successful
-    if (result.path.size() > 0)
+    if (result.path.empty())
     {
-        // Simplify path with default settings
-        vamp::planning::SimplifySettings simplify_settings;
-        auto simplify_result = vamp::planning::simplify<Robot, rake, Robot::resolution>(
-            result.path, env_v, simplify_settings, rng);
+        path_buffer.clear();
+        return 0;
+    }
 
-        // Output configurations of simplified path
-        std::cout << std::fixed << std::setprecision(3);
-        for (const auto &config : simplify_result.path)
+    // Simplify path
+    vamp::planning::SimplifySettings simplify_settings;
+    auto simplify_result = vamp::planning::simplify<Robot, rake, Robot::resolution>(
+        result.path, env_v, simplify_settings, rng);
+
+    // Interpolate to smooth animation (target ~100 waypoints)
+    simplify_result.path.interpolate_to_n_states(100);
+
+    // Store path as flat array: path_len * 7 floats
+    auto &path = simplify_result.path;
+    path_buffer.resize(path.size() * Robot::dimension);
+    for (std::size_t i = 0; i < path.size(); ++i)
+    {
+        const auto &arr = path[i].to_array();
+        for (std::size_t j = 0; j < Robot::dimension; ++j)
         {
-            const auto &array = config.to_array();
-            for (auto i = 0U; i < Robot::dimension; ++i)
-            {
-                std::cout << array[i] << ", ";
-            }
-
-            std::cout << std::endl;
+            path_buffer[i * Robot::dimension + j] = arr[j];
         }
     }
 
-    return 0;
+    return static_cast<int>(path.size());
+}
+
+EMSCRIPTEN_KEEPALIVE
+float *vamp_get_path_data()
+{
+    return path_buffer.data();
+}
+
+EMSCRIPTEN_KEEPALIVE
+int vamp_get_path_dof()
+{
+    return static_cast<int>(Robot::dimension);
+}
+
+// Legacy entry point for backward compatibility with wasm_planning.js
+EMSCRIPTEN_KEEPALIVE
+float vamp_wasm_planning()
+{
+    int path_len = vamp_plan();
+    return static_cast<float>(path_len);
 }
 
 } // extern "C"

--- a/src/impl/vamp/vector/interface.hh
+++ b/src/impl/vamp/vector/interface.hh
@@ -818,7 +818,7 @@ namespace vamp
         using DataT = typename Sig::DataT;
         using RowT = Vector<S, 1, num_scalars_per_row>;
 
-        DataT data{0};
+        DataT data{};
 
         constexpr Vector() noexcept = default;
 

--- a/src/impl/vamp/vector/wasm.hh
+++ b/src/impl/vamp/vector/wasm.hh
@@ -166,7 +166,7 @@ namespace vamp
         template <unsigned int = 0>
         inline static constexpr auto shift_right(VectorT v, unsigned int i) noexcept -> VectorT
         {
-            return VectorT{wasm_i32x4_shr(v.v, static_cast<int>(i))};
+            return VectorT{wasm_u32x4_shr(v.v, static_cast<int>(i))};
         }
 
         template <unsigned int = 0>
@@ -484,7 +484,7 @@ namespace vamp
         template <unsigned int = 0>
         inline static constexpr auto shift_right(VectorT v, unsigned int i) noexcept -> VectorT
         {
-            v128_t vi = wasm_i32x4_shr(v.v, static_cast<int>(i));
+            v128_t vi = wasm_u32x4_shr(v.v, static_cast<int>(i));
             return VectorT{vi};
         }
 
@@ -732,7 +732,7 @@ namespace vamp
         {
             if constexpr (std::is_same_v<OtherVectorT, wasm_i32x4>)
             {
-                // Map [0, UINT_MAX] to [0, 1]
+                // Map signed int32 bit patterns to approximately [-0.5, 0.5]
                 auto v1 = wasm_i32x4_and(v.v, wasm_i32x4_splat(1));
                 auto v1f = wasm_f32x4_convert_i32x4(v1);
                 auto vf = wasm_f32x4_convert_i32x4(v.v);

--- a/src/impl/vamp/vector/wasm.hh
+++ b/src/impl/vamp/vector/wasm.hh
@@ -307,7 +307,7 @@ namespace vamp
         template <std::size_t idx>
         inline static constexpr auto broadcast_dispatch(VectorT v) noexcept -> VectorT
         {
-            float lane;
+            float lane = 0.0f;
             if constexpr (idx == 0)
                 lane = wasm_f32x4_extract_lane(v.v, 0);
             else if constexpr (idx == 1)
@@ -509,7 +509,7 @@ namespace vamp
         template <unsigned int = 0>
         inline static constexpr auto hsum(VectorT v) noexcept -> ScalarT
         {
-            float out[4];
+            float out[4] = {};
             wasm_v128_store(out, v.v);
             return out[0] + out[1] + out[2] + out[3];
         }


### PR DESCRIPTION
## Summary

- **Fix PR #1 issues**: Remove global `-w` flag that suppressed all compiler warnings; fix README expected output (16.0 not 17.0); remove redundant manual `em++` linking instructions
- **Rewrite `wasm_planning.cc`** with a structured C API for JavaScript consumption: `vamp_plan()`, `vamp_compute_fk()`, `vamp_get_obstacles()`, `vamp_get_path_data()`, etc. — replacing the old `std::cout`-based output with pointer-based data exchange via WASM heap
- **Add interactive Three.js demo** (`demo/threejs/index.html`) that loads the WASM planning module, runs RRTC planning in the browser, and visualizes the Panda robot as collision spheres with path animation, obstacle display, start/goal ghosts, and orbit controls

## Changes

| File | Description |
|------|-------------|
| `CMakeLists.txt` | Remove `-w`, export all planning functions from WASM target |
| `README.md` | Fix expected output, simplify build instructions, add Three.js demo reference |
| `src/impl/vamp/bindings/wasm_planning.cc` | Full rewrite with structured API (FK, obstacles, path data) |
| `demo/threejs/index.html` | New Three.js 3D visualization demo |
| `scripts/wasm_planning.js` | Updated to exercise new API |
| `scripts/README.md` | Document Three.js demo |

## Test plan

- [ ] Build WASM targets: `emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release && cmake --build build-wasm -j`
- [ ] Run smoke test: `node scripts/wasm_smoke.js` (expect `OK 16.000000`)
- [ ] Run planning test: `node scripts/wasm_planning.js` (expect path with ~100 waypoints)
- [ ] Serve repo root (`npx serve .`) and open `demo/threejs/index.html` — click Plan Path, then Play Animation
- [ ] Verify native (non-Emscripten) build is unaffected

https://claude.ai/code/session_01FL3rudhHM4r8zMt6VKR3Tv